### PR TITLE
Windows Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -420,3 +420,7 @@ gmon.out
 **/App/example
 **/App/engine
 **/App/dll
+
+
+# Ignore unordered_dense.h from https://github.com/martinus/unordered_dense/releases/tag/v4.4.0
+src/unordered_dense.h

--- a/book/cow.h
+++ b/book/cow.h
@@ -8,7 +8,12 @@
 #ifndef cow_h
 #define cow_h
 
+#ifndef USE_UNORDERED_DENSE_DIRECTLY
 #include <ankerl/unordered_dense.h>
+#else
+// Use unordered_dense.h from https://github.com/martinus/unordered_dense/releases/tag/v4.4.0 directly
+#include "unordered_dense.h"
+#endif
 #include <cstdint>
 
 using namespace ankerl::unordered_dense;

--- a/book/tiger.h
+++ b/book/tiger.h
@@ -8,7 +8,12 @@
 #ifndef tiger_h
 #define tiger_h
 
+#ifndef USE_UNORDERED_DENSE_DIRECTLY
 #include <ankerl/unordered_dense.h>
+#else
+// Use unordered_dense.h from https://github.com/martinus/unordered_dense/releases/tag/v4.4.0 directly
+#include "unordered_dense.h"
+#endif
 #include <cstdint>
 
 using namespace ankerl::unordered_dense;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -73,22 +73,17 @@ void Main()
     Font font{FontMethod::MSDF, 48};
     Font result_font{FontMethod::MSDF, 20};
     //画像読み込み
-#ifdef _WIN64
-    const String RESOURCE_PATH = U"./assets/";
-#else
-    const String RESOURCE_PATH = U"";
-#endif
-    TextureAsset::Register(U"null", Resource(RESOURCE_PATH + U"null.png"));
-    TextureAsset::Register(U"nullb", Resource(RESOURCE_PATH + U"nullb.png"));
-    TextureAsset::Register(U"white", Resource(RESOURCE_PATH + U"white.png"));
-    TextureAsset::Register(U"whiteb", Resource(RESOURCE_PATH + U"whiteb.png"));
-    TextureAsset::Register(U"black", Resource(RESOURCE_PATH + U"black.png"));
-    TextureAsset::Register(U"blackb", Resource(RESOURCE_PATH + U"blackb.png"));
-    TextureAsset::Register(U"title", Resource(RESOURCE_PATH + U"title.png"));
-    TextureAsset::Register(U"hako_default", Resource(RESOURCE_PATH + U"hako.png"));
-    TextureAsset::Register(U"hako_thinking", Resource(RESOURCE_PATH + U"thinking.png"));
-    TextureAsset::Register(U"hako_lose", Resource(RESOURCE_PATH + U"lose.png"));
-    TextureAsset::Register(U"hako_win", Resource(RESOURCE_PATH + U"win.png"));
+    TextureAsset::Register(U"null", Resource(U"null.png"));
+    TextureAsset::Register(U"nullb", Resource(U"nullb.png"));
+    TextureAsset::Register(U"white", Resource(U"white.png"));
+    TextureAsset::Register(U"whiteb", Resource(U"whiteb.png"));
+    TextureAsset::Register(U"black", Resource(U"black.png"));
+    TextureAsset::Register(U"blackb", Resource(U"blackb.png"));
+    TextureAsset::Register(U"title", Resource(U"title.png"));
+    TextureAsset::Register(U"hako_default", Resource(U"hako.png"));
+    TextureAsset::Register(U"hako_thinking", Resource(U"thinking.png"));
+    TextureAsset::Register(U"hako_lose", Resource(U"lose.png"));
+    TextureAsset::Register(U"hako_win", Resource(U"win.png"));
     //サイズ取得 & 計算
     stone_edge = (800-(TextureAsset(U"null").width()*8))/2;
     stone_size = TextureAsset(U"null").width();

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -4,19 +4,13 @@
 using namespace std;
 using App = SceneManager<String>;
 
-#ifdef _WIN64
-#define RESOURCE_PATH U"./assets/"
-#else
-#define RESOURCE_PATH U""
-#endif
-
 // builtin functions
+// if you are using C++20, you can just use std::popcount(x) for popcount
 #ifdef __GNUC__
-    #define	popcountll(x) popcountll(x)
+#define popcountll(x) __builtin_popcountll(x)
 #else
-    #define	popcountll(x) __popcnt64(x)
+#define	popcountll(x) __popcnt64(x)
 #endif
-// if you are using C++20, you can just use std::popcount(x)
 
 int stone_edge, stone_size;
 
@@ -79,6 +73,11 @@ void Main()
     Font font{FontMethod::MSDF, 48};
     Font result_font{FontMethod::MSDF, 20};
     //画像読み込み
+#ifdef _WIN64
+    const String RESOURCE_PATH = U"./assets/";
+#else
+    const String RESOURCE_PATH = U"";
+#endif
     TextureAsset::Register(U"null", Resource(RESOURCE_PATH + U"null.png"));
     TextureAsset::Register(U"nullb", Resource(RESOURCE_PATH + U"nullb.png"));
     TextureAsset::Register(U"white", Resource(RESOURCE_PATH + U"white.png"));

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -4,6 +4,12 @@
 using namespace std;
 using App = SceneManager<String>;
 
+#ifdef _WIN64
+#define RESOURCE_PATH U"./assets/"
+#else
+#define RESOURCE_PATH U""
+#endif
+
 int stone_edge, stone_size;
 
 void DrawBoard() {
@@ -65,17 +71,17 @@ void Main()
     Font font{FontMethod::MSDF, 48};
     Font result_font{FontMethod::MSDF, 20};
     //画像読み込み
-    TextureAsset::Register(U"null", Resource(U"null.png"));
-    TextureAsset::Register(U"nullb", Resource(U"nullb.png"));
-    TextureAsset::Register(U"white", Resource(U"white.png"));
-    TextureAsset::Register(U"whiteb", Resource(U"whiteb.png"));
-    TextureAsset::Register(U"black", Resource(U"black.png"));
-    TextureAsset::Register(U"blackb", Resource(U"blackb.png"));
-    TextureAsset::Register(U"title", Resource(U"title.png"));
-    TextureAsset::Register(U"hako_default", Resource(U"hako.png"));
-    TextureAsset::Register(U"hako_thinking", Resource(U"thinking.png"));
-    TextureAsset::Register(U"hako_lose", Resource(U"lose.png"));
-    TextureAsset::Register(U"hako_win", Resource(U"win.png"));
+    TextureAsset::Register(U"null", Resource(RESOURCE_PATH + U"null.png"));
+    TextureAsset::Register(U"nullb", Resource(RESOURCE_PATH + U"nullb.png"));
+    TextureAsset::Register(U"white", Resource(RESOURCE_PATH + U"white.png"));
+    TextureAsset::Register(U"whiteb", Resource(RESOURCE_PATH + U"whiteb.png"));
+    TextureAsset::Register(U"black", Resource(RESOURCE_PATH + U"black.png"));
+    TextureAsset::Register(U"blackb", Resource(RESOURCE_PATH + U"blackb.png"));
+    TextureAsset::Register(U"title", Resource(RESOURCE_PATH + U"title.png"));
+    TextureAsset::Register(U"hako_default", Resource(RESOURCE_PATH + U"hako.png"));
+    TextureAsset::Register(U"hako_thinking", Resource(RESOURCE_PATH + U"thinking.png"));
+    TextureAsset::Register(U"hako_lose", Resource(RESOURCE_PATH + U"lose.png"));
+    TextureAsset::Register(U"hako_win", Resource(RESOURCE_PATH + U"win.png"));
     //サイズ取得 & 計算
     stone_edge = (800-(TextureAsset(U"null").width()*8))/2;
     stone_size = TextureAsset(U"null").width();

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -10,6 +10,14 @@ using App = SceneManager<String>;
 #define RESOURCE_PATH U""
 #endif
 
+// builtin functions
+#ifdef __GNUC__
+    #define	popcountll(x) popcountll(x)
+#else
+    #define	popcountll(x) __popcnt64(x)
+#endif
+// if you are using C++20, you can just use std::popcount(x)
+
 int stone_edge, stone_size;
 
 void DrawBoard() {
@@ -141,11 +149,11 @@ void Main()
             if (isFinished()) {
                 game_status = 3;
                 if (nowTurn == BLACK_TURN) {
-                    black_stone_count = __builtin_popcountll(b.playerboard);
-                    white_stone_count = __builtin_popcountll(b.opponentboard);
+                    black_stone_count = popcountll(b.playerboard);
+                    white_stone_count = popcountll(b.opponentboard);
                 } else {
-                    white_stone_count = __builtin_popcountll(b.playerboard);
-                    black_stone_count = __builtin_popcountll(b.opponentboard);
+                    white_stone_count = popcountll(b.playerboard);
+                    black_stone_count = popcountll(b.opponentboard);
                 }
                 if ((botplayer == 0 && black_stone_count > white_stone_count) || (botplayer == 1 && white_stone_count > black_stone_count)) {
                     winner = 0;

--- a/src/reversi.cpp
+++ b/src/reversi.cpp
@@ -156,7 +156,7 @@ void swapboard() {
 }
 
 inline int move_ordering_value(uint64_t &playerboard, uint64_t &opponentboard) {
-    if(afterIndex >= 64) return -__builtin_popcountll(makelegalboard(playerboard, opponentboard));
+    if(afterIndex >= 64) return -popcountll(makelegalboard(playerboard, opponentboard));
     auto it = former_transpose_table.find(make_pair(playerboard, opponentboard));
     if(it != former_transpose_table.end()) {
         return (1000-max(it->second.first, it->second.second));
@@ -391,7 +391,7 @@ int ai() {
     former_transpose_table.clear();
     legalboard = makelegalboard(b.playerboard, b.opponentboard);
 //    afterIndex = 60;
-    int putable_count = __builtin_popcountll(legalboard);
+    int putable_count = popcountll(legalboard);
     if (putable_count == 0) {
         swapboard();
         return 0;
@@ -432,7 +432,7 @@ int search(uint64_t &playerboard, uint64_t &opponentboard) {
     uint64_t rev;
     board_root m;
     vector<board_root> moveorder;
-    moveorder.reserve(__builtin_popcountll(legalboard));
+    moveorder.reserve(popcountll(legalboard));
     m.put = 1;
     for (auto i = 0; i < 64; ++i) {
         if(legalboard & m.put) {
@@ -445,7 +445,7 @@ int search(uint64_t &playerboard, uint64_t &opponentboard) {
     }
     int alpha = MIN_INF, beta = MAX_INF;
     if(Level == 7) {
-        think_count = 100/(__builtin_popcountll(legalboard)*4);
+        think_count = 100/(popcountll(legalboard)*4);
         for (search_depth = DEPTH-4; search_depth <= DEPTH; search_depth+=2) {
             afterIndex = nowIndex+search_depth;
             for (auto& m: moveorder) {
@@ -509,7 +509,7 @@ int search_nega_scout(uint64_t &playerboard, uint64_t &opponentboard) {
     uint64_t rev;
     board_root m;
     vector<board_root> moveorder;
-    moveorder.reserve(__builtin_popcountll(legalboard));
+    moveorder.reserve(popcountll(legalboard));
     m.put = 1;
     for (auto i = 0; i < 64; ++i) {
         if(legalboard & m.put) {
@@ -521,7 +521,7 @@ int search_nega_scout(uint64_t &playerboard, uint64_t &opponentboard) {
         m.put <<= 1;
     }
     int alpha = MIN_INF, beta = MAX_INF;
-    think_count = 100/(__builtin_popcountll(legalboard)*(DEPTH-max(1, DEPTH-4)+1));
+    think_count = 100/(popcountll(legalboard)*(DEPTH-max(1, DEPTH-4)+1));
     int wave = 0;
     for (search_depth = max(1, DEPTH-4); search_depth <= DEPTH; ++search_depth) {
         think_percent = wave*(100/(DEPTH-max(1, DEPTH-4)+1));
@@ -589,7 +589,7 @@ int nega_scout(int_fast8_t depth, int alpha, int beta, uint64_t &playerboard, ui
     }
     int var, max_score = MIN_INF, count = 0;
     uint64_t rev;
-    board moveorder[__builtin_popcountll(legalboard)];
+    board moveorder[popcountll(legalboard)];
     uint64_t put;
     while(legalboard) {
         put = legalboard & -legalboard;
@@ -679,7 +679,7 @@ int nega_alpha_moveorder(int_fast8_t depth, int alpha, int beta, uint64_t &playe
     }
     int var = 0, count = 0, max_score = MIN_INF;
     uint64_t rev;
-    board moveorder[__builtin_popcountll(legalboard)];
+    board moveorder[popcountll(legalboard)];
     uint64_t put;
     while(legalboard) {
         put = legalboard & -legalboard;
@@ -774,14 +774,14 @@ int search_finish_scout(uint64_t &playerboard, uint64_t &opponentboard) {
     uint64_t legalboard = makelegalboard(playerboard, opponentboard);
     int var = 0, score = 0;
     uint64_t rev;
-    board_finish_root moveorder[__builtin_popcountll(legalboard)];
+    board_finish_root moveorder[popcountll(legalboard)];
     for (uint64_t put = 0x8000000000000000; put >= 1; put >>= 1) {
         if(legalboard & put) {
             rev = Flip(put, playerboard, opponentboard);
             moveorder[var].playerboard = playerboard ^ (put | rev);
             moveorder[var].opponentboard = opponentboard ^ rev;
             moveorder[var].legalboard = makelegalboard(moveorder[var].opponentboard, moveorder[var].playerboard);
-            moveorder[var].score = __builtin_popcountll(moveorder[var].legalboard);
+            moveorder[var].score = popcountll(moveorder[var].legalboard);
             moveorder[var].put = put;
             ++var;
         }
@@ -829,12 +829,12 @@ int nega_scout_finish(int alpha, int beta, uint64_t &playerboard, uint64_t &oppo
     
     if(!legalboard) [[unlikely]] {
         uint64_t legalboard2 = makelegalboard(opponentboard, playerboard);
-        if(!legalboard2) [[unlikely]] return (__builtin_popcountll(playerboard) - __builtin_popcountll(opponentboard));
+        if(!legalboard2) [[unlikely]] return (popcountll(playerboard) - popcountll(opponentboard));
         else return -nega_scout_finish(-beta, -alpha, opponentboard, playerboard, legalboard2);
     }
     int var, max_score = MIN_INF, count = 0;
     uint64_t rev;
-    board_finish moveorder[__builtin_popcountll(legalboard)];
+    board_finish moveorder[popcountll(legalboard)];
     uint64_t put;
     while(legalboard) {
         put = legalboard & -legalboard;
@@ -843,7 +843,7 @@ int nega_scout_finish(int alpha, int beta, uint64_t &playerboard, uint64_t &oppo
         moveorder[count].playerboard = playerboard ^ (put | rev);
         moveorder[count].opponentboard = opponentboard ^ rev;
         moveorder[count].legalboard = makelegalboard(moveorder[count].opponentboard, moveorder[count].playerboard);
-        moveorder[count].score = __builtin_popcountll(moveorder[count].legalboard);
+        moveorder[count].score = popcountll(moveorder[count].legalboard);
         ++count;
     }
     
@@ -851,7 +851,7 @@ int nega_scout_finish(int alpha, int beta, uint64_t &playerboard, uint64_t &oppo
         return a.score < b.score;
     });
     
-    if(__builtin_popcountll(playerboard | opponentboard) <= 56) {
+    if(popcountll(playerboard | opponentboard) <= 56) {
         var = -nega_scout_finish(-beta, -alpha, moveorder[0].opponentboard, moveorder[0].playerboard, moveorder[0].legalboard);
         if (var >= beta) {
             if (var > l) {
@@ -917,12 +917,12 @@ int nega_alpha_moveorder_finish(int alpha, int beta, uint64_t &playerboard, uint
     
     if(!legalboard) [[unlikely]] {
         uint64_t legalboard2 = makelegalboard(opponentboard, playerboard);
-        if(!legalboard2) [[unlikely]] return (__builtin_popcountll(playerboard) - __builtin_popcountll(opponentboard));
+        if(!legalboard2) [[unlikely]] return (popcountll(playerboard) - popcountll(opponentboard));
         else return -nega_alpha_moveorder_finish(-beta, -alpha, opponentboard, playerboard, legalboard2);
     }
     int var = 0, count = 0, max_score = MIN_INF;
     uint64_t rev;
-    board_finish moveorder[__builtin_popcountll(legalboard)];
+    board_finish moveorder[popcountll(legalboard)];
     uint64_t put;
     while(legalboard) {
         put = legalboard & -legalboard;
@@ -931,14 +931,14 @@ int nega_alpha_moveorder_finish(int alpha, int beta, uint64_t &playerboard, uint
         moveorder[count].playerboard = playerboard ^ (put | rev);
         moveorder[count].opponentboard = opponentboard ^ rev;
         moveorder[count].legalboard = makelegalboard(moveorder[count].opponentboard, moveorder[count].playerboard);
-        moveorder[count].score = __builtin_popcountll(moveorder[count].legalboard);
+        moveorder[count].score = popcountll(moveorder[count].legalboard);
         ++count;
     }
     sort(execution::unseq, moveorder, moveorder+count, [](const auto &a, const auto &b) {
         return a.score < b.score;
     });
     
-    if(__builtin_popcountll(playerboard | opponentboard) <= 56) {
+    if(popcountll(playerboard | opponentboard) <= 56) {
         for (auto& m: moveorder) {
             var = -nega_alpha_moveorder_finish(-beta, -alpha, m.opponentboard, m.playerboard, m.legalboard);
             if (var >= beta) {
@@ -970,7 +970,7 @@ int nega_alpha_moveorder_finish(int alpha, int beta, uint64_t &playerboard, uint
 int nega_alpha_finish(int alpha, int beta, uint64_t &playerboard, uint64_t &opponentboard) {
     uint64_t legalboard = makelegalboard(playerboard, opponentboard);
     if(!legalboard) {
-        if(!(makelegalboard(opponentboard, playerboard))) return (__builtin_popcountll(playerboard) - __builtin_popcountll(opponentboard));
+        if(!(makelegalboard(opponentboard, playerboard))) return (popcountll(playerboard) - popcountll(opponentboard));
         else {
             return -nega_alpha_finish(-beta, -alpha, opponentboard, playerboard);
         }
@@ -997,11 +997,11 @@ int nega_alpha_finish(int alpha, int beta, uint64_t &playerboard, uint64_t &oppo
 
 int winner() {
     if(nowTurn == BLACK_TURN) {
-        blackc = __builtin_popcountll(b.playerboard);
-        whitec = __builtin_popcountll(b.opponentboard);
+        blackc = popcountll(b.playerboard);
+        whitec = popcountll(b.opponentboard);
     } else {
-        whitec = __builtin_popcountll(b.playerboard);
-        blackc = __builtin_popcountll(b.opponentboard);
+        whitec = popcountll(b.playerboard);
+        blackc = popcountll(b.opponentboard);
     }
     return (blackc > whitec) ? 1 : (blackc < whitec) ? 2 : 0;
 }
@@ -1036,7 +1036,7 @@ inline int score_stone(const uint64_t &playerboard, const uint64_t &opponentboar
 
     int score = 0;
     for (int i = 0; i < 4; ++i) {
-        score -= multipliers[i] * (__builtin_popcountll(playerboard & patterns[i])-__builtin_popcountll(opponentboard & patterns[i]));
+        score -= multipliers[i] * (popcountll(playerboard & patterns[i])-popcountll(opponentboard & patterns[i]));
     }
     for (int i = 0; i < 4; ++i) {
         if ((playerboard & LEFT_BOARD) == left_cases[i]) score += mask_scores[i];
@@ -1098,14 +1098,14 @@ inline int score_stone(const uint64_t &playerboard, const uint64_t &opponentboar
 }
 
 inline int score_putable(const uint64_t &playerboard, const uint64_t &opponentboard) {
-    return __builtin_popcountll(makelegalboard(playerboard, opponentboard))-__builtin_popcountll(makelegalboard(opponentboard, playerboard));
+    return popcountll(makelegalboard(playerboard, opponentboard))-popcountll(makelegalboard(opponentboard, playerboard));
 }
 
 inline int score_fixedstone(const uint64_t &playerboard, const uint64_t &opponentboard) {
     int fixedstone = 0;
     if(((playerboard | opponentboard) & DOWN_BOARD) == DOWN_BOARD) {
-        fixedstone += __builtin_popcountll(playerboard & DOWN_BOARD);
-        fixedstone -= __builtin_popcountll(opponentboard & DOWN_BOARD);
+        fixedstone += popcountll(playerboard & DOWN_BOARD);
+        fixedstone -= popcountll(opponentboard & DOWN_BOARD);
     } else {
         uint8_t mask = 0x80;
         while(mask & playerboard) {
@@ -1133,7 +1133,7 @@ inline int score_fixedstone(const uint64_t &playerboard, const uint64_t &opponen
 
 inline int score_fixedstone_table(const uint64_t &playerboard, const uint64_t &opponentboard) {
     return (!(0x8100000000000081ULL & (playerboard | opponentboard))) ? 0 :
-    (fixedstone_table[make_pair(playerboard & UP_BOARD, opponentboard & UP_BOARD)] + fixedstone_table[make_pair(playerboard & RIGHT_BOARD, opponentboard & RIGHT_BOARD)] + fixedstone_table[make_pair(playerboard & DOWN_BOARD, opponentboard & DOWN_BOARD)] + fixedstone_table[make_pair(playerboard & LEFT_BOARD, opponentboard & LEFT_BOARD)] - __builtin_popcountll(playerboard & 0x8100000000000081ULL) + __builtin_popcountll(opponentboard & 0x8100000000000081ULL));
+    (fixedstone_table[make_pair(playerboard & UP_BOARD, opponentboard & UP_BOARD)] + fixedstone_table[make_pair(playerboard & RIGHT_BOARD, opponentboard & RIGHT_BOARD)] + fixedstone_table[make_pair(playerboard & DOWN_BOARD, opponentboard & DOWN_BOARD)] + fixedstone_table[make_pair(playerboard & LEFT_BOARD, opponentboard & LEFT_BOARD)] - popcountll(playerboard & 0x8100000000000081ULL) + popcountll(opponentboard & 0x8100000000000081ULL));
 }
 
 inline int score_null_place(const uint64_t &playerboard, const uint64_t &opponentboard) {
@@ -1150,13 +1150,13 @@ inline int score_null_place(const uint64_t &playerboard, const uint64_t &opponen
     free_mask |= (free_board & LEFT_MASK) >> 7;
     free_mask |= free_board >> 8;
     
-    return __builtin_popcountll(opponentboard & free_mask)-__builtin_popcountll(playerboard & free_mask);
+    return popcountll(opponentboard & free_mask)-popcountll(playerboard & free_mask);
 }
 
 inline int countscore(const uint64_t &playerboard, const uint64_t &opponentboard) {
     if(!playerboard) [[unlikely]] return MIN_INF;
     if(!opponentboard) [[unlikely]] return MAX_INF;
-    if(afterIndex >= 64) return (__builtin_popcountll(playerboard)-__builtin_popcountll(opponentboard));
+    if(afterIndex >= 64) return (popcountll(playerboard)-popcountll(opponentboard));
     if(afterIndex >= 45) return (score_stone(playerboard, opponentboard)+score_fixedstone_table(playerboard, opponentboard)*4);
     if(afterIndex >= 41) return (score_stone(playerboard, opponentboard)*4+score_fixedstone_table(playerboard, opponentboard)*16 + score_putable(playerboard, opponentboard));
     else return (score_stone(playerboard, opponentboard)*6 + score_fixedstone_table(playerboard, opponentboard)*24 + score_putable(playerboard, opponentboard)*2 + score_null_place(playerboard, opponentboard)/2);

--- a/src/reversi.cpp
+++ b/src/reversi.cpp
@@ -8,6 +8,16 @@
 
 using namespace std;
 
+// builtin functions
+// if you are using C++20, you can just use std::popcount(x) for popcount
+#ifdef __GNUC__
+#define popcountll(x) __builtin_popcountll(x)
+#define clzll(x) __builtin_clzll(x)
+#else
+#define	popcountll(x) __popcnt64(x)
+#define clzll(x) _lzcnt_u64(x)
+#endif
+
 void reset() {
     printf("[*]初期化中...\n");
     nowTurn = BLACK_TURN;
@@ -97,17 +107,17 @@ inline uint64_t makelegalboard(const uint64_t &p, const uint64_t &o) {
 
 inline uint64_t Flip(const uint64_t &put, const uint64_t &playerboard, const uint64_t &opponentboard) {
     uint64_t flipped, OM, outflank[4], mask[4];
-    int pos = __builtin_clzll(put);
+    int pos = clzll(put);
     OM = opponentboard & 0x7e7e7e7e7e7e7e7eULL;
     
     mask[0] = 0x0080808080808080ULL >> (pos);
     mask[1] = 0x7f00000000000000ULL >> (pos);
     mask[2] = 0x0102040810204000ULL >> (pos);
     mask[3] = 0x0040201008040201ULL >> (pos);
-    outflank[0] = (0x8000000000000000ULL >> __builtin_clzll(((opponentboard) & (((mask[0]) & ((mask[0]) - 1)))) ^ (mask[0]))) & playerboard;
-    outflank[1] = (0x8000000000000000ULL >> __builtin_clzll(((OM) & (((mask[1]) & ((mask[1]) - 1)))) ^ (mask[1]))) & playerboard;
-    outflank[2] = (0x8000000000000000ULL >> __builtin_clzll(((OM) & (((mask[2]) & ((mask[2]) - 1)))) ^ (mask[2]))) & playerboard;
-    outflank[3] = (0x8000000000000000ULL >> __builtin_clzll(((OM) & (((mask[3]) & ((mask[3]) - 1)))) ^ (mask[3]))) & playerboard;
+    outflank[0] = (0x8000000000000000ULL >> clzll(((opponentboard) & (((mask[0]) & ((mask[0]) - 1)))) ^ (mask[0]))) & playerboard;
+    outflank[1] = (0x8000000000000000ULL >> clzll(((OM) & (((mask[1]) & ((mask[1]) - 1)))) ^ (mask[1]))) & playerboard;
+    outflank[2] = (0x8000000000000000ULL >> clzll(((OM) & (((mask[2]) & ((mask[2]) - 1)))) ^ (mask[2]))) & playerboard;
+    outflank[3] = (0x8000000000000000ULL >> clzll(((OM) & (((mask[3]) & ((mask[3]) - 1)))) ^ (mask[3]))) & playerboard;
     flipped  = (-outflank[0] << 1) & mask[0];
     flipped |= (-outflank[1] << 1) & mask[1];
     flipped |= (-outflank[2] << 1) & mask[2];
@@ -405,7 +415,7 @@ int ai() {
         cout << "error" << endl;
         return 0;
     }
-    int count = __builtin_clzll(tmpbit);
+    int count = clzll(tmpbit);
     tmpy = count / 8;
     tmpx = count % 8;
     putstone(tmpy, tmpx);
@@ -541,7 +551,7 @@ int search_nega_scout(uint64_t &playerboard, uint64_t &opponentboard) {
                     tmpbit = moveorder[i].put;
                 }
             }
-            int pos = __builtin_clzll(moveorder[i].put);
+            int pos = clzll(moveorder[i].put);
             box[pos / 8][pos % 8] = var;
             alpha = max(var, alpha);
         }

--- a/src/reversi.cpp
+++ b/src/reversi.cpp
@@ -589,7 +589,7 @@ int nega_scout(int_fast8_t depth, int alpha, int beta, uint64_t &playerboard, ui
     }
     int var, max_score = MIN_INF, count = 0;
     uint64_t rev;
-    board moveorder[popcountll(legalboard)];
+    board moveorder[36];
     uint64_t put;
     while(legalboard) {
         put = legalboard & -legalboard;
@@ -679,7 +679,7 @@ int nega_alpha_moveorder(int_fast8_t depth, int alpha, int beta, uint64_t &playe
     }
     int var = 0, count = 0, max_score = MIN_INF;
     uint64_t rev;
-    board moveorder[popcountll(legalboard)];
+    board moveorder[36];
     uint64_t put;
     while(legalboard) {
         put = legalboard & -legalboard;
@@ -774,7 +774,7 @@ int search_finish_scout(uint64_t &playerboard, uint64_t &opponentboard) {
     uint64_t legalboard = makelegalboard(playerboard, opponentboard);
     int var = 0, score = 0;
     uint64_t rev;
-    board_finish_root moveorder[popcountll(legalboard)];
+    board_finish_root moveorder[36];
     for (uint64_t put = 0x8000000000000000; put >= 1; put >>= 1) {
         if(legalboard & put) {
             rev = Flip(put, playerboard, opponentboard);
@@ -834,7 +834,7 @@ int nega_scout_finish(int alpha, int beta, uint64_t &playerboard, uint64_t &oppo
     }
     int var, max_score = MIN_INF, count = 0;
     uint64_t rev;
-    board_finish moveorder[popcountll(legalboard)];
+    board_finish moveorder[36];
     uint64_t put;
     while(legalboard) {
         put = legalboard & -legalboard;
@@ -922,7 +922,7 @@ int nega_alpha_moveorder_finish(int alpha, int beta, uint64_t &playerboard, uint
     }
     int var = 0, count = 0, max_score = MIN_INF;
     uint64_t rev;
-    board_finish moveorder[popcountll(legalboard)];
+    board_finish moveorder[36];
     uint64_t put;
     while(legalboard) {
         put = legalboard & -legalboard;

--- a/src/reversi.h
+++ b/src/reversi.h
@@ -8,9 +8,6 @@
 #ifndef reversi_h
 #define reversi_h
 
-// Use unordered_dense.h from https://github.com/martinus/unordered_dense/releases/tag/v4.4.0 directly
-#define USE_UNORDERED_DENSE_DIRECTLY
-
 #define BLACK_TURN 0
 #define WHITE_TURN 1
 #define UP_BOARD 0xFF00000000000000ULL
@@ -28,6 +25,7 @@
 #ifndef USE_UNORDERED_DENSE_DIRECTLY
 #include <ankerl/unordered_dense.h>
 #else
+// Use unordered_dense.h from https://github.com/martinus/unordered_dense/releases/tag/v4.4.0 directly
 #include "unordered_dense.h"
 #endif
 #include <numeric>

--- a/src/reversi.h
+++ b/src/reversi.h
@@ -8,6 +8,9 @@
 #ifndef reversi_h
 #define reversi_h
 
+// Use unordered_dense.h from https://github.com/martinus/unordered_dense/releases/tag/v4.4.0 directly
+#define USE_UNORDERED_DENSE_DIRECTLY
+
 #define BLACK_TURN 0
 #define WHITE_TURN 1
 #define UP_BOARD 0xFF00000000000000ULL
@@ -22,7 +25,11 @@
 #include <vector>
 #include <algorithm>
 #include <bit>
+#ifndef USE_UNORDERED_DENSE_DIRECTLY
 #include <ankerl/unordered_dense.h>
+#else
+#include "unordered_dense.h"
+#endif
 #include <numeric>
 #include <cmath>
 #include <execution>


### PR DESCRIPTION
Windowsでビルドできるように若干修正しました。
やったことは以下の通りです
- GNUC以外でもビルドできるように、popcountとclzllを書き換え
- unsignedにマイナスをつけるとエラーになる場合があるので、2の補数表現で書き換え(パフォーマンスに影響する可能性があります)(エラー回避の方法が別であるような気はしますが…)
- unordered_denseヘッダファイル直置きに対応(USE_UNORDERED_DENSE_DIRECTLYをつけてコンパイルするとMain.cppと同じディレクトリにunordered_dense.hを置いてコンパイルできます)
- 配列の定義時、合法手数を計算してその分だけ配列を確保しているところがエラーになる場合があるので、36で固定([オセロであり得る最大の合法手数は33](https://eukaryote.hateblo.jp/entry/2023/05/17/163629)で、[初期盤面を任意にしたときにあり得る最大の合法手数は34](https://eukaryote.hateblo.jp/entry/2020/04/13/150458)なので、36でなくても34でOKだった気がします)

参考程度に見ていただけると幸いです